### PR TITLE
Load global typescript files

### DIFF
--- a/fixtures/ts-global/MyCompany/component/foo.ts
+++ b/fixtures/ts-global/MyCompany/component/foo.ts
@@ -1,0 +1,8 @@
+(function() {
+  window['MyCompany'] = {
+    component: {}
+  }
+
+  const foo: string = 'foo'
+  window['MyCompany'].component.foo = foo
+}())

--- a/src/createDomture.ts.spec.ts
+++ b/src/createDomture.ts.spec.ts
@@ -38,12 +38,12 @@ test('import global script', async t => {
   t.deepEqual(textBox, { a: 1 })
 })
 
-test(`preload global script with type`, async t => {
-  const harness = await createDomture({
-    transpiler: 'typescript',
-    preloadScripts: ['./fixtures/ts-global/MyCompany/component/foo']
-  })
+test(`import global script with type`, async t => {
+  const harness = await createDomture({ transpiler: 'typescript' })
+
+  await harness.import('./fixtures/ts-global/MyCompany/component/foo')
   const foo = harness.window.MyCompany.component.foo
+
   t.deepEqual(foo, 'foo')
 })
 

--- a/src/createDomture.ts.spec.ts
+++ b/src/createDomture.ts.spec.ts
@@ -24,13 +24,32 @@ test('with rootDir should still load packages', async t => {
   t.is(globalStore.default.name, 'create')
 })
 
-test('import global namespace script', async t => {
+test('import global script', async t => {
   const harness = await createDomture({ transpiler: 'typescript' })
   await harness.import('./fixtures/ts-global/MyCompany/component/TextBox')
   const textBox = harness.window.MyCompany.component.TextBox
   t.deepEqual(textBox, { a: 1 })
 })
 
+<<<<<<< 01730bc4648eeb43b6567ec2ce7d1de6aecc6388
+=======
+test('import global script', async t => {
+  const harness = await createDomture({ transpiler: 'typescript' })
+  await harness.import('./fixtures/ts-global/MyCompany/component/TextBox')
+  const textBox = harness.window.MyCompany.component.TextBox
+  t.deepEqual(textBox, { a: 1 })
+})
+
+test(`preload global script with type`, async t => {
+  const harness = await createDomture({
+    transpiler: 'typescript',
+    preloadScripts: ['./fixtures/ts-global/MyCompany/component/foo']
+  })
+  const foo = harness.window.MyCompany.component.foo
+  t.deepEqual(foo, 'foo')
+})
+
+>>>>>>> Add failing test
 test('load ts and js', async t => {
   const domture = await createDomture({
     rootDir: './fixtures/ts',

--- a/src/createDomture.ts.spec.ts
+++ b/src/createDomture.ts.spec.ts
@@ -31,8 +31,11 @@ test('import global script', async t => {
   t.deepEqual(textBox, { a: 1 })
 })
 
+<<<<<<< eb2d8ef892dd658bdb5b98e93d729a5296ef0348
 <<<<<<< 01730bc4648eeb43b6567ec2ce7d1de6aecc6388
 =======
+=======
+>>>>>>> Add failing test
 test('import global script', async t => {
   const harness = await createDomture({ transpiler: 'typescript' })
   await harness.import('./fixtures/ts-global/MyCompany/component/TextBox')

--- a/src/systemjsConfig.ts
+++ b/src/systemjsConfig.ts
@@ -46,7 +46,12 @@ const transpilerBuilders = {
       },
       packages: {
         'app': {
-          defaultExtension: 'ts'
+          defaultExtension: 'ts',
+          meta: {
+            '*.ts': {
+              loader: 'plugin-typescript'
+            }
+          }
         },
         'typescript': {
           'main': 'lib/typescript.js',


### PR DESCRIPTION
`meta/*.ts/loader: 'plugin-typescript'` is added.
All js/ts files should load through the transpiler by default.
Don't know why it is not working.