### PR TITLE
fix: adjust defaultConfig type to WebpackDomtureConfig

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -32,7 +32,7 @@ export interface SystemJSDomtureConfig extends DomtureConfigBase {
 
 export type DomtureConfig = WebpackDomtureConfig | SystemJSDomtureConfig
 
-export const defaultConfig: DomtureConfig = {
+export const defaultConfig: WebpackDomtureConfig = {
   loader: 'webpack',
   packageManager: 'npm',
   rootDir: '.',

--- a/src/createDomture.ts
+++ b/src/createDomture.ts
@@ -1,6 +1,6 @@
 import { unpartial } from 'unpartial'
 
-import { WebpackDomtureConfig, SystemJSDomtureConfig, defaultConfig } from './config'
+import { WebpackDomtureConfig, SystemJSDomtureConfig, defaultConfig, DomtureConfig } from './config'
 import { Domture, SystemJSDomture } from './interfaces'
 import { createWebpackDomture } from './createWebpackDomture'
 import { createSystemJSDomture } from './createSystemJSDomture';
@@ -8,7 +8,7 @@ import { createSystemJSDomture } from './createSystemJSDomture';
 export async function createDomture(givenConfig?: Partial<WebpackDomtureConfig>): Promise<Domture>
 export async function createDomture(givenConfig?: Partial<SystemJSDomtureConfig>): Promise<SystemJSDomture>
 export async function createDomture(givenConfig: Partial<SystemJSDomtureConfig> | Partial<WebpackDomtureConfig> = {}): Promise<SystemJSDomture | Domture> {
-  const config = unpartial(defaultConfig, givenConfig)
+  const config = unpartial<DomtureConfig>(defaultConfig, givenConfig)
   return config.loader === 'webpack' ?
     createWebpackDomture(config) :
     createSystemJSDomture(config)


### PR DESCRIPTION
Casting it to DomtureConfig causes config merging error when using spread operator.

// error, moduleFileExtensions not in WebpackDomtureConfig
const c: WebpackDomtureConfig = { ...defaultConfig, ... }