### PR TITLE
fix: relax JSDOM constructor options

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -15,7 +15,9 @@ export interface DomtureConfigBase {
   rootDir: string,
   transpiler: Transpiler,
   preloadScripts?: string[],
-  jsdomConstructorOptions?: ConstructorOptions
+  // `@types/jsdom` is not updated with some of the options.
+  // enable any key
+  jsdomConstructorOptions?: ConstructorOptions & { [k: string]: any }
 }
 
 export interface WebpackDomtureConfig extends DomtureConfigBase {


### PR DESCRIPTION
`@types/jsdom` is lagging behind. Missing options such as `pretendToBeVisual`.

Relaxing the interface for now.